### PR TITLE
Fix bugs, update naming conventions and improve typing hints

### DIFF
--- a/sungc/rasterio_funcs.py
+++ b/sungc/rasterio_funcs.py
@@ -6,10 +6,10 @@ import rasterio
 import rasterio.mask
 import numpy as np
 
-from typing import Union
 from pathlib import Path
 from rasterio import DatasetReader
 from rasterio.warp import reproject, Resampling
+from typing import Union, List, Tuple
 
 
 def check_image_singleval(image: np.ndarray, value: Union[float, int], img_name: str):
@@ -38,7 +38,7 @@ def get_resample_bandname(filename: Path, spatial_res: Union[int, float, str]) -
     return out_base
 
 
-def load_singleband(rio_file: Path):
+def load_singleband(rio_file: Path) -> Tuple[np.ndarray, dict]:
     """
     Loads file as a numpy.ndarray
 
@@ -62,7 +62,9 @@ def load_singleband(rio_file: Path):
     return img, meta
 
 
-def load_bands(bandlist: list, scale_factor: Union[int, float], apply_scaling: bool):
+def load_bands(
+    bandlist: list, scale_factor: Union[int, float], apply_scaling: bool
+) -> Tuple[np.ndarray, dict]:
     """
     load the bands in bandlist into a 3D array.
 
@@ -83,6 +85,9 @@ def load_bands(bandlist: list, scale_factor: Union[int, float], apply_scaling: b
     -------
     spectral_cube : numpy.ndarray
         multi-band array with dimensions of [nbands, nrows, ncols]
+
+    meta : dict
+        rasterio metadata
     """
     if scale_factor <= 0:
         raise Exception("load_bands: scale_factor <= 0")
@@ -127,7 +132,7 @@ def resample_bands(
     load=True,
     save=False,
     odir: Union[Path, None] = None,
-):
+) -> Tuple[Union[List[Path], None], Union[np.ndarray, None], Union[dict, None]]:
     """
     Resample bands (bandlist) to the specified
     spatial resolution using the specified resampling option
@@ -401,7 +406,7 @@ def resample_band_to_ds(
     return resampled_img
 
 
-def load_mask_from_shp(shp_file: Path, ref_ds: DatasetReader):
+def load_mask_from_shp(shp_file: Path, ref_ds: DatasetReader) -> np.ndarray:
     """
     Load a mask containing geometries from a shapefile,
     using a reference dataset

--- a/sungc/xarr_funcs.py
+++ b/sungc/xarr_funcs.py
@@ -7,7 +7,9 @@ import pandas as pd
 from datetime import datetime
 
 
-def create_xr(xr_dvars: dict, meta: dict, overpass_datetime: datetime, desc: str):
+def create_xr(
+    xr_dvars: dict, meta: dict, overpass_datetime: datetime, desc: str
+) -> xr.Dataset:
     """
     Create an xarray object
 

--- a/tests/test_hedley_sung.py
+++ b/tests/test_hedley_sung.py
@@ -31,8 +31,8 @@ odc_meta_file = data_path / "ga_ls8c_aard_3-2-0_091086_2014-11-06_final.odc-meta
 
 shp_file = data_path / "HEDLEY" / "ga_ls8c_oa_3-2-0_091086_2014-11-06_final_dw_ROI.shp"
 
-# specify the product
-product = "lmbadj"
+# specify the sub_product
+sub_product = "lmbadj"
 
 
 def test_hedley_image(tmp_path):
@@ -40,7 +40,7 @@ def test_hedley_image(tmp_path):
     Test if the generated deglinted band is nearly identical
     to expected deglinted band
     """
-    g = deglint.GlintCorr(odc_meta_file, product)
+    g = deglint.GlintCorr(odc_meta_file, sub_product)
     hedley_dir = tmp_path / "HEDLEY"
     hedley_dir.mkdir()
 
@@ -49,8 +49,8 @@ def test_hedley_image(tmp_path):
     # ------------------ #
     # deglint the vis bands using band 6
     hedley_xarrlist = g.hedley_2005(
-        vis_band_ids=["3"],
-        nir_band_id="6",
+        vis_bands=["3"],
+        corr_band="6",
         roi_shpfile=shp_file,
         overwrite_shp=False,
         odir=hedley_dir,
@@ -85,10 +85,10 @@ def test_hedley_plot(tmp_path):
     hedley_dir = tmp_path / "HEDLEY"
     hedley_dir.mkdir()
 
-    g = deglint.GlintCorr(odc_meta_file, product)
+    g = deglint.GlintCorr(odc_meta_file, sub_product)
     g.hedley_2005(
-        vis_band_ids=["3"],
-        nir_band_id="6",
+        vis_bands=["3"],
+        corr_band="6",
         roi_shpfile=shp_file,
         overwrite_shp=False,
         odir=hedley_dir,
@@ -106,9 +106,9 @@ def test_hedley_plot(tmp_path):
 def test_hedley_bands(tmp_path):
     """
     Ensure that hedley_2005() raises an Exception if
-    the specifued vis_band_id and nir_band_id do not exist
+    the specifued vis_band_id and corr_band do not exist
     """
-    g = deglint.GlintCorr(odc_meta_file, product)
+    g = deglint.GlintCorr(odc_meta_file, sub_product)
 
     hedley_dir = tmp_path / "HEDLEY"
     hedley_dir.mkdir()
@@ -116,8 +116,8 @@ def test_hedley_bands(tmp_path):
     # check VIS band
     with pytest.raises(Exception) as excinfo:
         g.hedley_2005(
-            vis_band_ids=["20"],  # this band doesn't exist
-            nir_band_id="6",
+            vis_bands=["20"],  # this band doesn't exist
+            corr_band="6",
             roi_shpfile=shp_file,
             overwrite_shp=False,
             odir=hedley_dir,
@@ -129,8 +129,8 @@ def test_hedley_bands(tmp_path):
     # check NIR band
     with pytest.raises(Exception) as excinfo:
         g.hedley_2005(
-            vis_band_ids=["3"],
-            nir_band_id="20",  # this band doesn't exist
+            vis_bands=["3"],
+            corr_band="20",  # this band doesn't exist
             roi_shpfile=shp_file,
             overwrite_shp=False,
             odir=hedley_dir,
@@ -145,15 +145,15 @@ def test_empty_band(tmp_path):
     Ensure that hedley_2005() raises an Exception if
     the VIS and NIR band only contain nodata pixels
     """
-    g = deglint.GlintCorr(odc_meta_file, product)
+    g = deglint.GlintCorr(odc_meta_file, sub_product)
 
     hedley_dir = tmp_path / "HEDLEY"
     hedley_dir.mkdir()
 
     with pytest.raises(Exception) as excinfo:
         g.hedley_2005(
-            vis_band_ids=["7"],  # dummy band only contains nodata (-999)
-            nir_band_id="6",
+            vis_bands=["7"],  # dummy band only contains nodata (-999)
+            corr_band="6",
             roi_shpfile=shp_file,
             overwrite_shp=False,
             odir=hedley_dir,
@@ -164,8 +164,8 @@ def test_empty_band(tmp_path):
 
     with pytest.raises(Exception) as excinfo:
         g.hedley_2005(
-            vis_band_ids=["3"],
-            nir_band_id="7",  # dummy band only contains nodata (-999)
+            vis_bands=["3"],
+            corr_band="7",  # dummy band only contains nodata (-999)
             roi_shpfile=shp_file,
             overwrite_shp=False,
             odir=hedley_dir,
@@ -180,7 +180,7 @@ def test_fake_shp(tmp_path):
     Ensure that hedley_2005() raises an Exception if
     the input shapefile isn't really a shapefile
     """
-    g = deglint.GlintCorr(odc_meta_file, product)
+    g = deglint.GlintCorr(odc_meta_file, sub_product)
 
     hedley_dir = tmp_path / "HEDLEY"
     hedley_dir.mkdir()
@@ -191,8 +191,8 @@ def test_fake_shp(tmp_path):
 
     with pytest.raises(Exception) as excinfo:
         g.hedley_2005(
-            vis_band_ids=["3"],
-            nir_band_id="6",
+            vis_bands=["3"],
+            corr_band="6",
             roi_shpfile=fake_shp,
             overwrite_shp=False,
             odir=hedley_dir,
@@ -207,7 +207,7 @@ def test_failure_point_shp(tmp_path):
     Ensure that hedley_2005() raises an Exception if
     the shapefile does not contain any Polygon geometries
     """
-    g = deglint.GlintCorr(odc_meta_file, product)
+    g = deglint.GlintCorr(odc_meta_file, sub_product)
 
     hedley_dir = tmp_path / "HEDLEY"
     hedley_dir.mkdir()
@@ -239,8 +239,8 @@ def test_failure_point_shp(tmp_path):
             )
     with pytest.raises(Exception) as excinfo:
         g.hedley_2005(
-            vis_band_ids=["3"],
-            nir_band_id="6",
+            vis_bands=["3"],
+            corr_band="6",
             roi_shpfile=point_shp,
             overwrite_shp=False,
             odir=hedley_dir,
@@ -270,8 +270,8 @@ def test_failure_point_shp(tmp_path):
         )
     with pytest.raises(Exception) as excinfo:
         g.hedley_2005(
-            vis_band_ids=["3"],
-            nir_band_id="6",
+            vis_bands=["3"],
+            corr_band="6",
             roi_shpfile=linestr_shp,
             overwrite_shp=False,
             odir=hedley_dir,

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -19,8 +19,8 @@ odc_meta_file = (
     / "data/ga_ls8c_aard_3-2-0_091086_2014-11-06_final.odc-metadata.yaml"
 )
 
-# specify the product
-product = "lmbadj"
+# specify the sub_product
+sub_product = "lmbadj"
 
 
 def test_interactive_figure():
@@ -32,7 +32,7 @@ def test_interactive_figure():
     Note that the unittest on g.quicklook_rgb() is performed in
     test_quicklook_rgb.py
     """
-    g = deglint.GlintCorr(odc_meta_file, product)
+    g = deglint.GlintCorr(odc_meta_file, sub_product)
 
     # generate a quicklook
     rgb_im, rgb_meta = g.quicklook_rgb(dwnscale_factor=3)
@@ -45,7 +45,7 @@ def test_interactive_figure():
     mc.interative()
 
     # Ensure that mc.canvas is the correct type.
-    assert isinstance(mc.canvas, backend_qt5agg.FigureCanvasQTAgg)
+    assert isinstance(mc.canvas, backend_qt5agg.FigureCanvasAgg)
 
 
 def test_interactive_failure():

--- a/tests/test_mnir_sungc.py
+++ b/tests/test_mnir_sungc.py
@@ -15,28 +15,24 @@ from . import urd
 data_path = Path(__file__).parent / "data"
 odc_meta_file = data_path / "ga_ls8c_aard_3-2-0_091086_2014-11-06_final.odc-metadata.yaml"
 
-# specify the product
-product = "lmbadj"
+# specify the sub_product
+sub_product = "lmbadj"
 
 
-def test_mnir_image(tmp_path):
+def test_mnir_image():
     """
     Check that the generated deglinted band is nearly identical
     to the expected deglinted band
     """
     # Initiate the sunglint correction class
-    g = deglint.GlintCorr(odc_meta_file, product)
+    g = deglint.GlintCorr(odc_meta_file, sub_product)
 
     # ---------------------- #
     #     NIR subtraction    #
     # ---------------------- #
-    mnir_dir = tmp_path / "MINUS_NIR"
-    mnir_dir.mkdir()
-
-    mnir_xarrlist = g.nir_subtraction(
-        vis_band_ids=["3"],
-        nir_band_id="6",
-        odir=mnir_dir,
+    mnir_xarrlist = g.glint_subtraction(
+        vis_bands=["3"],
+        corr_band="6",
         water_val=5,
     )
 
@@ -55,59 +51,49 @@ def test_mnir_image(tmp_path):
         assert urd_band.max() < 0.001
 
 
-def test_mnir_bands(tmp_path):
+def test_mnir_bands():
     """
-    Ensure that nir_subtraction() raises and Exception if
-    the specified vis_band_id/nir_band_id do not exist
+    Ensure that glint_subtraction() raises and Exception if
+    the specified vis_band_id/corr_band do not exist
     """
-    g = deglint.GlintCorr(odc_meta_file, product)
-
-    mnir_dir = tmp_path / "MINUS_NIR"
-    mnir_dir.mkdir()
+    g = deglint.GlintCorr(odc_meta_file, sub_product)
 
     with pytest.raises(Exception) as excinfo:
-        g.nir_subtraction(
-            vis_band_ids=["20"],  # this band id doesn't exist
-            nir_band_id="6",
-            odir=mnir_dir,
+        g.glint_subtraction(
+            vis_bands=["20"],  # this band id doesn't exist
+            corr_band="6",
             water_val=5,
         )
     assert "is missing from bands" in str(excinfo)
 
     with pytest.raises(Exception) as excinfo:
-        g.nir_subtraction(
-            vis_band_ids=["3"],
-            nir_band_id="20",  # this band id doesn't exist
-            odir=mnir_dir,
+        g.glint_subtraction(
+            vis_bands=["3"],
+            corr_band="20",  # this band id doesn't exist
             water_val=5,
         )
     assert "is missing from bands" in str(excinfo)
 
 
-def test_empty_inputs(tmp_path):
+def test_empty_inputs():
     """
-    Ensure that nir_subtraction() raises and Exception if
+    Ensure that glint_subtraction() raises and Exception if
     the VIS and NIR band only contain nodata pixels
     """
-    g = deglint.GlintCorr(odc_meta_file, product)
-
-    mnir_dir = tmp_path / "MINUS_NIR"
-    mnir_dir.mkdir()
+    g = deglint.GlintCorr(odc_meta_file, sub_product)
 
     with pytest.raises(Exception) as excinfo:
-        g.nir_subtraction(
-            vis_band_ids=["3"],
-            nir_band_id="7",  # this dummy band only contains nodata
-            odir=mnir_dir,
+        g.glint_subtraction(
+            vis_bands=["3"],
+            corr_band="7",  # this dummy band only contains nodata
             water_val=5,
         )
     assert "only contains a single value" in str(excinfo)
 
     with pytest.raises(Exception) as excinfo:
-        g.nir_subtraction(
-            vis_band_ids=["7"],  # this dummy band only contains nodata
-            nir_band_id="6",
-            odir=mnir_dir,
+        g.glint_subtraction(
+            vis_bands=["7"],  # this dummy band only contains nodata
+            corr_band="6",
             water_val=5,
         )
     assert "only contains a single value" in str(excinfo)


### PR DESCRIPTION
In this PR:
1. Naming conventions were changed (`product` -> `sub_product`; `nir_subtraction `-> `glint_subtraction`; `vis_band_ids` -> `vis_bands`, `nir_band_id` -> `corr_band`);
2. Fxed bug associated with the dictionary returned by `create_res_dict`;
3. Fixed bug associated with sensor name. In this ticket, the sensor name is concatenated to, for instance, "sentinel2a" from either "sentinel-2a" or "sentinel_2a";
4. Improved typing hints;
5. Updated tests to accommodate changes made in (1).