### PR TITLE
Force interactive figure to block.

### DIFF
--- a/sungc/interactive.py
+++ b/sungc/interactive.py
@@ -132,7 +132,7 @@ class RoiSelector(object):
         canvas.mpl_connect("key_press_event", self.key_press_callback)
         canvas.mpl_connect("motion_notify_event", self.motion_notify_callback)
         self.canvas = canvas
-        plt.show()
+        plt.show(block=True)
 
     def default_vertices(self, ax: matplotlib.axes.Axes) -> tuple:
         """


### PR DESCRIPTION
Force the matplotlib figure to block in order for the kernel to wait for user events that reshape the default polygon, and collect the final vertices when the figure is closed. This fixes the issue with interactive mode within a Jupyter notebook where the figure is displayed and doesn't block resulting in the default polygon being used to collect band stats and derive a linear relationship.

Resolves #18 